### PR TITLE
Bug fixes for twitter data format issues

### DIFF
--- a/bin/embed_tweets_2_sql.py
+++ b/bin/embed_tweets_2_sql.py
@@ -61,6 +61,19 @@ if __name__ == '__main__':
             except json.JSONDecodeError:
                 print('Json decode error in line {}. Skipped'.format(i))
                 continue
+
+            # CB 20200326: Adding this check to remove instances
+            #  where we have a retweeted_status and quoted_status
+            #  field but they are NONE. This can happen if the data
+            #  source of the tweets embed these fields because some
+            #  tweets have them. E.g., Pandas does this when you read
+            #  in tweets to a DataFrame and then export them to JSON
+            if "retweeted_status" in tweet and tweet["retweeted_status"] is None:
+                tweet.pop("retweeted_status")
+            if "quoted_status" in tweet and tweet["quoted_status"] is None:
+                tweet.pop("quoted_status")
+
+            # Now process the tweet as normal
             tweet_html, tweet_id = read_tweet(tweet)
 
             if tweet_html is None:

--- a/bin/tweets2sql.py
+++ b/bin/tweets2sql.py
@@ -45,6 +45,18 @@ with codecs.open(tweetPath, "r", "utf8") as inFile:
 	for line in inFile:
 		tweet = json.loads(line)
 
+        # CB 20200326: Adding this check to remove instances
+        #  where we have a retweeted_status and quoted_status
+        #  field but they are NONE. This can happen if the data
+        #  source of the tweets embed these fields because some
+        #  tweets have them. E.g., Pandas does this when you read
+        #  in tweets to a DataFrame and then export them to JSON
+        if "retweeted_status" in tweet and tweet["retweeted_status"] is None:
+            tweet.pop("retweeted_status")
+        if "quoted_status" in tweet and tweet["quoted_status"] is None:
+            tweet.pop("quoted_status")
+
+        # Now process the tweet as normal
 		(tweetText, tweetId) = readTweet(tweet)
 
 		if ( tweetText == None ):

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -166,6 +166,7 @@ def read_tweet(tweet):
                        'Quoted text: {quoted_text}</pre>'),
         'retweet_of_quotetweet': ('<pre>Tweet type: {type}</br>'
                                   'Author: {author}</br>'
+                                  'Tweet text: {text}</br>'
                                   'Retweeted author: {retweeted_author}</br>'
                                   'Retweeted text: {retweeted_text}</br>'
                                   'Quoted author: {quoted_author}</br>'


### PR DESCRIPTION
If pandas exports Twitter JSON data, it adds "retweetd_status" and "quoted_status" fields to all tweets. This addition breaks a lot of the underlying logic in the code since we expect the presence of those tweets to be flags for tweet type. I fix this now by deleting these keys if their values are null, as that should never happen.